### PR TITLE
Better tilde support

### DIFF
--- a/plugin/vim-npr.vim
+++ b/plugin/vim-npr.vim
@@ -56,20 +56,13 @@ function! VimNPRFindFile(cmd) abort
     let l:resolveDirs = g:vim_npr_default_dirs
   endtry
 
-  " if path starts with ~ (tilde) replace it with package dir
-  if l:cfile =~ '^\~'
-    let l:possiblePath = substitute(l:cfile, '\~', l:packageDir, 'g')
-
-    for filename in g:vim_npr_file_names
-      if filereadable(possiblePath . filename)
-        return s:edit_file(possiblePath . filename, a:cmd)
-      endif
-    endfor
-  endif
-
   " Iterate over potential directories and search for the file
   for dir in l:resolveDirs
-    let l:possiblePath = l:packageDir . "/" . dir . "/" . l:cfile
+    if l:cfile =~ '^\~'
+      let l:possiblePath = substitute(l:cfile, '\~', l:packageDir . "/" . dir . "/", 'g')
+    else
+      let l:possiblePath = l:packageDir . "/" . dir . "/" . l:cfile
+    endif
 
     for filename in g:vim_npr_file_names
       if filereadable(possiblePath . filename)


### PR DESCRIPTION
If path starts with ~ (tilde), it replaces it with package dir.

In some projects,  `~` is not used to alias a package directory but an src folder or anything that can be in the `resolve` value of the package.json.

This change resolve that.